### PR TITLE
fix: added missing maintenance columns

### DIFF
--- a/db/datalakes_schema.sql
+++ b/db/datalakes_schema.sql
@@ -269,7 +269,10 @@ CREATE TABLE public.maintenance (
     description character varying,
     reporter character varying,
     datasets_id integer,
-    datasetparameters_id integer
+    datasetparameters_id integer,
+    state character varying,
+    issue character varying,
+    request character varying
 );
 
 


### PR DESCRIPTION
Since SQL migration tool was removed, the default startup SQL schema should at least contain the new maintenance columns. 